### PR TITLE
Fixed bugs with dependency version generation

### DIFF
--- a/src/drom_lib/dune.ml
+++ b/src/drom_lib/dune.ml
@@ -100,8 +100,8 @@ let template_dune_project p =
             | Lt version -> Printf.bprintf b "( < %s )" version
             | Le version -> Printf.bprintf b "( <= %s )" version
             | Eq version -> Printf.bprintf b "( = %s )" version
-            | Ge version -> Printf.bprintf b "( > %s )" version
-            | Gt version -> Printf.bprintf b "( >= %s )" version )
+            | Ge version -> Printf.bprintf b "( >= %s )" version
+            | Gt version -> Printf.bprintf b "( > %s )" version )
           | version :: tail ->
             Printf.bprintf b "(and ";
             iter [ version ];

--- a/src/drom_lib/misc.ml
+++ b/src/drom_lib/misc.ml
@@ -210,7 +210,7 @@ let semantic_version version =
   match EzString.split version '.' with
   | [ major; minor; fix ] -> (
     try Some (int_of_string major, int_of_string minor, int_of_string fix)
-    with Not_found -> None )
+    with Failure _ -> None )
   | _ -> None
 
 let underscorify s =


### PR DESCRIPTION
There were a couple of small bugs with version generation (came across them when trying to add base as a dependency since it's version starts with "v"); this fixes them.