### PR TITLE
Fix broken output by passing dev_null to Misc.call in commandRun

### DIFF
--- a/src/drom_lib/commandRun.ml
+++ b/src/drom_lib/commandRun.ml
@@ -27,9 +27,11 @@ let action ~args ~cmd ~package =
       | Program -> p.package.name :: cmd
       | Virtual -> cmd )
   in
+  let dev_null = Unix.openfile "/dev/null" [Unix.O_RDWR] 0o0655 in
   Misc.call
     (Array.of_list
        ("opam" :: "exec" :: "--" :: "dune" :: "exec" :: "--" :: cmd))
+    ~stdout:dev_null
 
 let cmd =
   let cmd = ref [] in


### PR DESCRIPTION
As the title says.

You can recreate the problem by:
```
drom new hello && cd hello
drom install -y
drom run hello
```

and the output is broken as follows:

```
~/hello
λ drom run hello
Hello world!         anned 0 directories
```