### PR TITLE
Add command hooks

### DIFF
--- a/.drom
+++ b/.drom
@@ -2,7 +2,7 @@
 
 # hash of toml configuration files
 # used for generation of all files
-dff636cbe399e29f256a1483400e4c29:.
+48d17e09406369916a414d7ccd132e58:.
 # end context for .
 
 # begin context for .github/workflows/doc-deploy.yml
@@ -37,7 +37,7 @@ c4217a22064a4a18f9587b930b250fbe:LICENSE.md
 
 # begin context for Makefile
 # file Makefile
-ef1b0c16bc9c975ebe772ff5357dc30f:Makefile
+145f1b16e2d9822e10578e9ca9ed8fea:Makefile
 # end context for Makefile
 
 # begin context for README.md
@@ -77,7 +77,7 @@ b091dd96e8b553dd7a7df285279d7d9e:README.md
 
 # begin context for drom.opam
 # file drom.opam
-921f270eed0e5dee73153c852aff0a1d:drom.opam
+cb5791c65a49e3c7fd453b331b6ca587:drom.opam
 # end context for drom.opam
 
 # begin context for drom.toml
@@ -87,18 +87,28 @@ b091dd96e8b553dd7a7df285279d7d9e:README.md
 
 # begin context for drom_lib.opam
 # file drom_lib.opam
-9e3add3dce40d01537aa6258731c2bdd:drom_lib.opam
+b4e73f360c324bc5c790c16576bbc818:drom_lib.opam
 # end context for drom_lib.opam
 
 # begin context for dune
 # file dune
-0a2b3465c7b9e4510548b78ec4d4e39e:dune
+75e6233439d4b052fad9d368155ca723:dune
 # end context for dune
 
 # begin context for dune-project
 # file dune-project
 8ef5717bd75c05ee5d5fdff782e782fc:dune-project
 # end context for dune-project
+
+# begin context for scripts/after.sh
+# file scripts/after.sh
+1112fbe7067fce342365a25613b5659d:scripts/after.sh
+# end context for scripts/after.sh
+
+# begin context for scripts/before.sh
+# file scripts/before.sh
+ae050b3099ac0b43d7c7f4295f6b2319:scripts/before.sh
+# end context for scripts/before.sh
 
 # begin context for sphinx/_static/css/fixes.css
 # file sphinx/_static/css/fixes.css

--- a/drom.opam
+++ b/drom.opam
@@ -27,6 +27,7 @@ dev-repo: "git+https://github.com/ocamlpro/drom.git"
 tags: "org:ocamlpro"
 build: [
   ["dune" "subst"] {dev}
+  ["sh" "-c" "./scripts/before.sh" "build" name]
   [
     "dune"
     "build"
@@ -38,6 +39,10 @@ build: [
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["sh" "-c" "./scripts/after.sh" "build" name]
+]
+install: [
+  ["sh" "-c" "./scripts/before.sh" "install" name]
 ]
 depends: [
   "ocaml" {>= "4.07.0"}

--- a/drom_lib.opam
+++ b/drom_lib.opam
@@ -27,6 +27,7 @@ dev-repo: "git+https://github.com/ocamlpro/drom.git"
 tags: "org:ocamlpro"
 build: [
   ["dune" "subst"] {dev}
+  ["sh" "-c" "./scripts/before.sh" "build" name]
   [
     "dune"
     "build"
@@ -38,6 +39,10 @@ build: [
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["sh" "-c" "./scripts/after.sh" "build" name]
+]
+install: [
+  ["sh" "-c" "./scripts/before.sh" "install" name]
 ]
 depends: [
   "ocaml" {>= "4.07.0"}

--- a/dune
+++ b/dune
@@ -148,6 +148,10 @@
     as "skeletons/projects/virtual/dune-project_")
    ( "share/drom/skeletons/projects/virtual/dune_"
     as "skeletons/projects/virtual/dune_")
+   ( "share/drom/skeletons/projects/virtual/scripts/after.sh"
+    as "skeletons/projects/virtual/scripts/after.sh")
+   ( "share/drom/skeletons/projects/virtual/scripts/before.sh"
+    as "skeletons/projects/virtual/scripts/before.sh")
    ( "share/drom/skeletons/projects/virtual/skeleton.toml"
     as "skeletons/projects/virtual/skeleton.toml")
    ( "share/drom/skeletons/projects/virtual/sphinx/about.rst"

--- a/scripts/after.sh
+++ b/scripts/after.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Read more on this file in before.sh
+
+COMMAND=$1
+shift
+SCRIPT=./scripts/after-${COMMAND}.sh
+
+if [ -e ${SCRIPT} ]; then
+   exec ${SCRIPT} $*
+fi

--- a/scripts/before.sh
+++ b/scripts/before.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# This script and after.sh are used to mimic drom hooks from the Makefile
+# and opam file.
+# drom calls the following hooks:
+#  * before-build.sh [PACKAGE] (PACKAGE only provided if called from opam for PACKAGE.opam)
+#  * after-build.sh  [PACKAGE]
+#  * before-sphinx.sh SPHINX_TARGET
+#  * after-sphinx.sh SPHINX_TARGET
+#  * before-odoc.sh ODOC_TARGET
+#  * after-odoc.sh ODOC_TARGET
+#  * before-test.sh
+#  * after-test.sh
+#  * before-install.sh PACKAGE
+#  * after-clean.sh
+#  * after-distclean.sh
+#  * before-fmt.sh
+#  * after-fmt.sh
+#  * before-run.sh CMD ARGS
+#  * before-publish.sh OPAM_REPO
+#  * after-publish.sh OPAM_REPO
+
+COMMAND=$1
+shift
+SCRIPT=./scripts/before-${COMMAND}.sh
+
+if [ -e ${SCRIPT} ]; then
+   exec ${SCRIPT} $*
+fi

--- a/share/drom/skeletons/projects/virtual/Makefile
+++ b/share/drom/skeletons/projects/virtual/Makefile
@@ -4,10 +4,18 @@
 
 DEV_DEPS := merlin ocamlformat odoc![if:gen:test] ppx_expect ppx_inline_test![fi]
 
+![if:gen:docs]![if:gen:sphinx]
+SPHINX_TARGET:=_drom/docs/!{sphinx-target}
+![fi]
+ODOC_TARGET:=_drom/docs/!{odoc-target}/.
+![fi]
+
 all: build
 
 build:
+	./scripts/before.sh build
 	opam exec -- dune build @install!{make-copy-programs}
+	./scripts/after.sh build
 
 build-deps:
 	if ! [ -e _opam ]; then \
@@ -17,22 +25,21 @@ build-deps:
 
 ![if:gen:docs]
 .PHONY: doc-common odoc view![if:gen:sphinx] sphinx![fi]
-doc-common:
-	opam exec -- dune build @doc
+doc-common: build
 	mkdir -p _drom/docs
 	rsync -auv docs/. _drom/docs/.
 ![if:gen:sphinx]
-sphinx: doc-common 
-	if [ -e ./scripts/before-sphinx.sh ]; then \
-		./scripts/before-sphinx.sh _drom/docs/!{sphinx-target}; \
-	else \
-		echo No file ./scripts/before-sphinx.sh; \
-	fi
-	sphinx-build sphinx _drom/docs/!{sphinx-target}
+sphinx: doc-common
+	./scripts/before.sh sphinx ${SPHINX_TARGET}
+	sphinx-build sphinx ${SPHINX_TARGET}
+	./scripts/after.sh sphinx  ${SPHINX_TARGET}
 ![fi]
-odoc: doc-common 
-	mkdir -p _drom/docs/!{odoc-target}/.
-	rsync -auv --delete _build/default/_doc/_html/. _drom/docs/!{odoc-target}
+odoc: doc-common
+	mkdir -p ${ODOC_TARGET}
+	./scripts/before.sh odoc ${ODOC_TARGET}
+	opam exec -- dune build @doc
+	rsync -auv --delete _build/default/_doc/_html/. ${ODOC_TARGET}
+	./scripts/after.sh odoc ${ODOC_TARGET}
 
 doc: doc-common odoc![if:gen:sphinx] sphinx![fi]
 
@@ -46,24 +53,29 @@ fmt-check:
 	opam exec -- dune build @fmt
 
 install:
-	opam exec -- dune install
+	opam pin -y --no-action -k path .
+	opam install -y .
 
 opam:
 	opam pin -k path .
 
 uninstall:
-	opam exec -- dune uninstall
+	opam uninstall .
 
 dev-deps:
 	opam install ./*.opam --deps-only --with-doc --with-test
 
 test:
+	./scripts/before.sh test
 	opam exec -- dune build @runtest
+	./scripts/after.sh test
 
 clean:
 	rm -rf _build
+	./scripts/after.sh clean
 
 distclean: clean
 	rm -rf _opam _drom
+	./scripts/after.sh distclean
 
 !(makefile-trailer)

--- a/share/drom/skeletons/projects/virtual/dot_github/workflows/doc-deploy.yml
+++ b/share/drom/skeletons/projects/virtual/dot_github/workflows/doc-deploy.yml
@@ -36,12 +36,7 @@ jobs:
         if: steps.cache-opam.outputs.cache-hit == 'true'
       - name: build-doc
         run: |
-          mkdir -p _drom/docs
-          rsync -auv docs/. _drom/docs/.
-          opam exec -- dune build @doc
-          mkdir -p _drom/docs/doc
-          rsync -auv _build/default/_doc/_html/. _drom/docs/!{odoc-target}/.
-          sphinx-build sphinx _drom/docs/!{sphinx-target}
+          make doc
           touch _drom/docs/.nojekyll
           touch _drom/docs/!{sphinx-target}/.nojekyll
           touch _drom/docs/!{odoc-target}/.nojekyll

--- a/share/drom/skeletons/projects/virtual/dot_github/workflows/workflow.yml
+++ b/share/drom/skeletons/projects/virtual/dot_github/workflows/workflow.yml
@@ -59,13 +59,13 @@ jobs:
       - run: opam upgrade --fixup
         if: steps.cache-opam.outputs.cache-hit == 'true'
 
-      - run: opam exec -- dune build @install
+      - run: make build
 
       - name: run test suite
-        run: opam exec -- dune build @runtest
+        run: make test
         if: matrix.skip_test  != 'true'
 
       - name: test source is well formatted
-        run: opam exec -- dune build @fmt
+        run: make fmt
         continue-on-error: true
         if: matrix.ocaml-version == '!{edition}' && matrix.os == 'ubuntu-latest'

--- a/share/drom/skeletons/projects/virtual/scripts/after.sh
+++ b/share/drom/skeletons/projects/virtual/scripts/after.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Read more on this file in before.sh
+
+COMMAND=$1
+shift
+SCRIPT=./scripts/after-${COMMAND}.sh
+
+if [ -e ${SCRIPT} ]; then
+   exec ${SCRIPT} $*
+fi

--- a/share/drom/skeletons/projects/virtual/scripts/before.sh
+++ b/share/drom/skeletons/projects/virtual/scripts/before.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# This script and after.sh are used to mimic drom hooks from the Makefile
+# and opam file.
+# drom calls the following hooks:
+#  * before-build.sh [PACKAGE] (PACKAGE only provided if called from opam for PACKAGE.opam)
+#  * after-build.sh  [PACKAGE]
+#  * before-sphinx.sh SPHINX_TARGET
+#  * after-sphinx.sh SPHINX_TARGET
+#  * before-odoc.sh ODOC_TARGET
+#  * after-odoc.sh ODOC_TARGET
+#  * before-test.sh
+#  * after-test.sh
+#  * before-install.sh PACKAGE
+#  * after-clean.sh
+#  * after-distclean.sh
+#  * before-fmt.sh
+#  * after-fmt.sh
+#  * before-run.sh CMD ARGS
+#  * before-publish.sh OPAM_REPO
+#  * after-publish.sh OPAM_REPO
+
+COMMAND=$1
+shift
+SCRIPT=./scripts/before-${COMMAND}.sh
+
+if [ -e ${SCRIPT} ]; then
+   exec ${SCRIPT} $*
+fi

--- a/sphinx/commands.rst
+++ b/sphinx/commands.rst
@@ -19,6 +19,9 @@ Overview of sub-commands::
   clean
     Clean the project from build files
   
+  config
+    Read/write configuration
+  
   dep (since version 0.2.1)
     Manage dependency of a package
   
@@ -170,7 +173,44 @@ Clean the project from build files
 Where options are:
 
 
-* :code:`--opam`   Also remove the local opam switch (_opam/ and _drom/)
+* :code:`--distclean`   Also remove _opam/ (local switch) and _drom/
+
+
+drom config
+~~~~~~~~~~~~~
+
+Read/write configuration
+
+
+
+**DESCRIPTION**
+
+
+This command is useful to read/write drom configuration
+
+
+**EXAMPLE**
+
+
+The following displays the list of project skeletons:
+::
+  
+  drom config --project-skeletons
+  
+
+**USAGE**
+::
+  
+  drom config [OPTIONS]
+
+Where options are:
+
+
+* :code:`--drom-project-skeletons`   List available project skeletons from drom
+
+* :code:`--package-skeletons`   List available package skeletons
+
+* :code:`--project-skeletons`   List available project skeletons
 
 
 drom dep (since version 0.2.1)
@@ -425,7 +465,7 @@ Create a new project
 **DESCRIPTION**
 
 
-This command performs the following actions:
+This command creates a new project, with name **PROJECT** in a directory **PROJECT** (unless the **--inplace** argument was provided).
 
 
 **EXAMPLE**

--- a/src/drom_lib/build.ml
+++ b/src/drom_lib/build.ml
@@ -356,7 +356,8 @@ had_switch: %b
         Opam.run ~y [ "install" ] packages
   end;
 
-  if build then
+  if build then begin
+    Misc.before_hook "build";
     Opam.run [ "exec" ]
       ( [ "--"; "dune"; "build"; "@install" ]
         @
@@ -374,4 +375,6 @@ had_switch: %b
         )
 
       );
+    Misc.after_hook "build";
+  end;
   p

--- a/src/drom_lib/commandClean.ml
+++ b/src/drom_lib/commandClean.ml
@@ -13,23 +13,25 @@ open EZCMD.TYPES
 
 let cmd_name = "clean"
 
-let action ~opam =
+let action ~distclean =
   let _p,_ = Project.get () in
   Printf.eprintf "Removing _build...\n%!";
   ignore (Sys.command "rm -rf _build");
-  if !opam then (
+  Misc.after_hook "clean";
+  if !distclean then (
     ignore (Sys.command "rm -rf _drom");
-    ignore (Sys.command "rm -rf _opam")
+    ignore (Sys.command "rm -rf _opam");
+    Misc.after_hook "distclean";
   )
 
 let cmd =
-  let opam = ref false in
+  let distclean = ref false in
   EZCMD.sub
     cmd_name
-    (fun () -> action ~opam)
+    (fun () -> action ~distclean)
     ~args:
-      [ ( [ "opam" ],
-          Arg.Set opam,
-          EZCMD.info "Also remove the local opam switch (_opam/ and _drom/)" )
+      [ ( [ "distclean" ],
+          Arg.Set distclean,
+          EZCMD.info "Also remove _opam/ (local switch) and _drom/" )
       ]
     ~doc: "Clean the project from build files"

--- a/src/drom_lib/commandFmt.ml
+++ b/src/drom_lib/commandFmt.ml
@@ -15,6 +15,7 @@ let cmd_name = "fmt"
 
 let action ~args ~auto_promote () =
   let (_p : Types.project) = Build.build ~dev_deps:true ~build:false ~args () in
+  Misc.before_hook "fmt";
   Misc.call
     (Array.of_list
        ( [ "opam"; "exec"; "--"; "dune"; "build"; "@fmt" ]
@@ -22,7 +23,9 @@ let action ~args ~auto_promote () =
        if auto_promote then
          [ "--auto-promote" ]
        else
-         [] ))
+         [] ));
+  Misc.after_hook "fmt";
+  ()
 
 let cmd =
   let auto_promote = ref false in

--- a/src/drom_lib/commandInstall.ml
+++ b/src/drom_lib/commandInstall.ml
@@ -17,10 +17,11 @@ let action ~args () =
     Error.raise "Cannot install project if the project has vendors/ packages";
 
   let _p = Build.build ~args () in
+  let y = args.arg_yes in
   let packages = Misc.list_opam_packages "." in
-  Opam.run [ "pin" ] [ "-y"; "--no-action"; "-k"; "path"; "." ];
+  Opam.run ~y [ "pin" ] [ "--no-action"; "-k"; "path"; "." ];
   let exn =
-    match Opam.run [ "install" ] ("-y" :: packages) with
+    match Opam.run ~y [ "install" ] ("-y" :: packages) with
     | () -> None
     | exception exn -> Some exn
   in

--- a/src/drom_lib/commandPublish.ml
+++ b/src/drom_lib/commandPublish.ml
@@ -43,6 +43,7 @@ let action ~force ~opam_repo ~use_md5 () =
         | None ->
             Error.raise "You must specify the path to a copy of opam-repository" )
   in
+  Misc.before_hook "publish" ~args:[ opam_repo ];
   let opam_packages_dir = opam_repo // "packages" in
   if not (Sys.file_exists opam_packages_dir) then
     Error.raise "packages dir does not exist in repo %S" opam_repo;
@@ -137,7 +138,7 @@ url {
             !created;
           raise exn)
     ".";
-
+  Misc.after_hook "publish" ~args:[ opam_repo ];
   ()
 
 let cmd =

--- a/src/drom_lib/commandRun.ml
+++ b/src/drom_lib/commandRun.ml
@@ -27,6 +27,7 @@ let action ~args ~cmd ~package =
       | Program -> p.package.name :: cmd
       | Virtual -> cmd )
   in
+  Misc.before_hook "run" ~args:cmd;
   Misc.call
     (Array.of_list
        ("opam" :: "exec" :: "--" :: "dune" :: "exec" :: "--" :: cmd))

--- a/src/drom_lib/commandSphinx.ml
+++ b/src/drom_lib/commandSphinx.ml
@@ -16,10 +16,9 @@ let cmd_name = "sphinx"
 let make_sphinx p =
   let dir = Misc.sphinx_target p in
   let sphinx_target = Format.sprintf "_drom/docs/%s" dir in
-  let before_script =  "scripts/before-sphinx.sh" in
-  if Sys.file_exists before_script then
-    Misc.call [| before_script ; sphinx_target |];
+  Misc.before_hook "sphinx" ~args:[ sphinx_target ];
   Misc.call [| "sphinx-build"; "sphinx"; sphinx_target |];
+  Misc.after_hook "sphinx" ~args:[ sphinx_target ];
   sphinx_target
 
 let action ~args ~open_www () =

--- a/src/drom_lib/misc.ml
+++ b/src/drom_lib/misc.ml
@@ -332,3 +332,13 @@ let package_skeleton package =
   match package.p_skeleton with
   | Some skeleton -> skeleton
   | None -> string_of_kind package.kind
+
+let hook ?(args=[]) script =
+  if Sys.file_exists script then
+    call ( Array.of_list (script :: args) )
+
+let before_hook ?args command =
+  hook ?args (Printf.sprintf "./scripts/before-%s.sh" command)
+
+let after_hook ?args command =
+  hook ?args (Printf.sprintf "./scripts/after-%s.sh" command)

--- a/src/drom_lib/opam.ml
+++ b/src/drom_lib/opam.ml
@@ -65,13 +65,23 @@ let opam_of_project kind package =
                 {|
 [
   ["dune" "subst"] {dev}
+  ["sh" "-c" "./scripts/before.sh" "build" name]
   ["dune" "build" "-p" name "-j" jobs "@install"
-     "@runtest" {with-test}
-    "@doc" {with-doc}
+     "@runtest" {with-test} "@doc" {with-doc}
   ]
+  ["sh" "-c" "./scripts/after.sh" "build" name]
 ]
 |}
-                filename )
+                filename );
+          var "install"
+            (
+              OpamParser.FullPos.value_from_string
+                {|
+[
+  ["sh" "-c" "./scripts/before.sh" "install" name]
+]
+|} filename
+            );
         ]
   in
   let depend_of_dep name d =

--- a/src/drom_lib/skeleton.mli
+++ b/src/drom_lib/skeleton.mli
@@ -15,6 +15,7 @@ val write_files :
   content:string ->
   record:bool ->
   skip:bool ->
+  perm:int ->
   unit) ->
   Types.project ->
   unit

--- a/src/drom_lib/types.ml
+++ b/src/drom_lib/types.ml
@@ -139,7 +139,7 @@ type flags =
 type skeleton =
   { skeleton_inherits : string option;
     skeleton_toml : string list;
-    skeleton_files : (string * string) list;
+    skeleton_files : (string * string * int) list;
     skeleton_flags : flags StringMap.t;
     skeleton_drom : bool ;
     skeleton_name : string ;


### PR DESCRIPTION
The following hooks can be used (listed in scripts/before.sh):
* before-build.sh [PACKAGE] (PACKAGE only provided if
   called from opam for PACKAGE.opam)
* after-build.sh  [PACKAGE]
* before-sphinx.sh SPHINX_TARGET
* after-sphinx.sh SPHINX_TARGET
* before-odoc.sh ODOC_TARGET
* after-odoc.sh ODOC_TARGET
* before-test.sh
* after-test.sh
* before-install.sh PACKAGE (called from opam install)
* after-clean.sh
* after-distclean.sh
* before-fmt.sh
* after-fmt.sh
* before-run.sh CMD ARGS
* before-publish.sh OPAM_REPO
* after-publish.sh OPAM_REPO

Other modifications:
* `drom clean --distclean` instead of `drom clean --opam`
* Keep file permissions from skeletons (especially for scripts)