### PR TITLE
use master as a default branch name for git init to avoid a warning

### DIFF
--- a/src/drom_lib/git.ml
+++ b/src/drom_lib/git.ml
@@ -18,6 +18,11 @@ let email () =
   | Some email -> email
   | None -> raise Not_found
 
+let init_default_branch () =
+  match Misc.call_get_fst_line "git config --get init.defaultBranch" with
+  | Some branch -> branch
+  | None -> "master"
+
 let call args = Misc.call (Array.of_list ("git" :: args))
 
 let run args = try call args with _ -> ()

--- a/src/drom_lib/update.ml
+++ b/src/drom_lib/update.ml
@@ -240,7 +240,8 @@ let update_files ?args ?(git = false) ?(create = false) p =
   Hashes.with_ctxt ~git (fun hashes ->
       if create then
         if git && not (Sys.file_exists ".git") then (
-          Git.call [ "init" ];
+          let branch_name = Git.init_default_branch () in
+          Git.call [ "init"; "-b"; branch_name ];
           match config.config_github_organization with
           | None -> ()
           | Some organization ->


### PR DESCRIPTION
Without this commit, when creating a new project, you get something like:

```
astuce: Utilisation de 'master' comme nom de la branche initiale. Le nom de la branche
astuce: par défaut peut changer. Pour configurer le nom de la branche initiale
astuce: pour tous les nouveaux dépôts, et supprimer cet avertissement, lancez :
astuce: 
astuce: 	git config --global init.defaultBranch <nom>
astuce: 
astuce: Les noms les plus utilisés à la place de 'master' sont 'main', 'trunk' et
astuce: 'development'. La branche nouvellement créée peut être rénommée avec :
astuce: 
astuce: 	git branch -m <nom>
```

Now, we check if `init.defaultBranch` is set. If it is, we use it, otherwise we use "master" as a default.