### PR TITLE
Fix git init for git < 2.28

### DIFF
--- a/src/drom_lib/update.ml
+++ b/src/drom_lib/update.ml
@@ -241,7 +241,8 @@ let update_files ?args ?(git = false) ?(create = false) p =
       if create then
         if git && not (Sys.file_exists ".git") then (
           let branch_name = Git.init_default_branch () in
-          Git.call [ "init"; "-b"; branch_name ];
+          Git.call [ "init" ];
+          Git.call [ "checkout"; "-b"; branch_name ];
           match config.config_github_organization with
           | None -> ()
           | Some organization ->


### PR DESCRIPTION
Because `git init -b` is only suported on recent git versions.