### PR TITLE
Fix dune test files generation

### DIFF
--- a/share/drom/skeletons/projects/virtual/test/output-tests/dune_
+++ b/share/drom/skeletons/projects/virtual/test/output-tests/dune_
@@ -4,9 +4,11 @@
 ; that we generate else-where
 
 (rule
- (with-stdout-to
-  test1.output
-  (run cat test1.expected)))
+ (deps test1.expected)
+ (action
+  (with-stdout-to
+   test1.output
+   (run cat test1.expected))))
 
 (rule
  (alias runtest)

--- a/test/output-tests/dune
+++ b/test/output-tests/dune
@@ -4,9 +4,11 @@
 ; that we generate else-where
 
 (rule
- (with-stdout-to
-  test1.output
-  (run cat test1.expected)))
+ (deps test1.expected)
+ (action
+  (with-stdout-to
+   test1.output
+   (run cat test1.expected))))
 
 (rule
  (alias runtest)

--- a/test/output-tests/dune_
+++ b/test/output-tests/dune_
@@ -4,9 +4,11 @@
 ; that we generate else-where
 
 (rule
- (with-stdout-to
-  test1.output
-  (run cat test1.expected)))
+ (deps test1.expected)
+ (action
+  (with-stdout-to
+   test1.output
+   (run cat test1.expected))))
 
 (rule
  (alias runtest)


### PR DESCRIPTION
Turns out drom generated faulty dune rules for its "output-tests" (that somehow worked in previous versions up until the upcoming dune 2.8.0)

This PR fixes the issue and make project generated using drom compatible with dune 2.8.0.

See https://github.com/ocaml/dune/issues/4110