### PR TITLE
remove stray printf

### DIFF
--- a/src/drom_lib/commandRun.ml
+++ b/src/drom_lib/commandRun.ml
@@ -36,9 +36,7 @@ let cmd =
   let package = ref None in
   let args, specs = Build.build_args () in
   EZCMD.sub cmd_name
-    (fun () ->
-       Printf.eprintf "aaa\n\n%!";
-       action ~args ~cmd:!cmd ~package:!package)
+    (fun () -> action ~args ~cmd:!cmd ~package:!package)
     ~args: (
       [ ( [ "p" ],
           Arg.String (fun s -> package := Some s),


### PR DESCRIPTION
This string is printed on every call to run. It seems to be mistakenly left in.