### PR TITLE
Print better error msgs when drom fails to parse package name

### DIFF
--- a/src/drom_lib/project.ml
+++ b/src/drom_lib/project.ml
@@ -412,7 +412,13 @@ let find_package ?default name =
 let package_of_toml ?default ?p_file table =
   let dir = EzToml.get_string_option table [ "dir" ] in
   let name = try EzToml.get_string table [ "name" ] with Not_found ->
-    Printf.eprintf "Error: Missing field 'name' in package.toml\n%!";
+    ( match dir with
+      | Some dir_path ->
+        let package_path = dir_path // "package.toml" in
+        if Sys.file_exists package_path
+        then Printf.eprintf "Error: Missing field 'name' in %s\n%!" package_path
+        else Printf.eprintf "Error: %s is missing \n%!" package_path
+      | None -> Printf.eprintf "Error: Missing field 'name' for a package in drom.toml\n%!" );
     exit 2
   in
   let default = find_package ?default name in


### PR DESCRIPTION
This is for issue [117](https://github.com/OCamlPro/drom/issues/177).

At this point Drom does not mention which package has the problem when it fails to parse name. This PR improves error msg by checking the package section's dir field and file existence

if dir field is `None`, error msg will say a package does not have name in `drom.toml` file.
If dir field is given but file cannot be found, the msg will say `package.toml` is missing
if dir field is given, then it will print `name` field is missing.