### PR TITLE
Add note detailing the location of the configuration file on MacOS

### DIFF
--- a/sphinx/install.rst
+++ b/sphinx/install.rst
@@ -82,6 +82,11 @@ two actions:
 
           share-dir = "/home/user/.opam/4.10.0/share/drom"
 
+.. note::
+  On MacOS the configuration file is can be found in the following location:
+  :: 
+      $HOME/Library/Application Support/com.ocamlpro.drom/config
+
 Note that you can also copy :code:`drom`'s share directory to a global
 location if don't want the files to be removed accidentally by an
 :code:`opam` operation.


### PR DESCRIPTION
# Patch Description

On MacOS, `opam` will use a different value for `Project_dirs.config_dir`; instead of `$HOME/.config/drom/`, it will instead use `$HOME/Library/Application Support/com.ocamlpro.drom`. This can lead to some baffling issues when trying to set up a global install of drom.

This patch adds a note to `install.rst` that flags this potential point of confusion, and points users to the correct location of the configuration file.