### PR TITLE
Fixed dune lang handling

### DIFF
--- a/src/drom_lib/project.ml
+++ b/src/drom_lib/project.ml
@@ -586,7 +586,7 @@ let project_of_toml ?file ?default table =
             p.name )
       packages;
     (* Legacy dune lang version specification *)
-    let legacy_dune_lang = StringMap.find_opt "dune" p_fields in
+    let legacy_dune_lang = StringMap.find_opt "dune-lang" p_fields in
     (* Checking that dune is not in project's dependencies, which has no more
        meaning than in packages *)
     if find dependencies then
@@ -594,7 +594,7 @@ let project_of_toml ?file ?default table =
         "Project has a dune dependency which has no meaning. Please remove it \
          or move it in [tools].";
     (* The valid way of overriding dune version. *)
-    let dune_tool_spec = List.assoc_opt "dune" dependencies in
+    let dune_tool_spec = List.assoc_opt "dune" tools in
     (* Normalizing *)
     let versions =
       match (legacy_dune_lang, dune_tool_spec) with

--- a/src/drom_lib/subst.ml
+++ b/src/drom_lib/subst.ml
@@ -268,8 +268,14 @@ let project_brace ({ p; _ }  as state ) v =
       end )
   (* for dune *)
   | "dune-version" -> p.dune_version
-  | "dune-lang" ->
-    String.sub p.dune_version 0 (String.rindex p.dune_version '.')
+  | "dune-lang" -> 
+    (* just parsing basic semver for now. *)
+    begin
+      try 
+        Scanf.sscanf p.dune_version "%i.%i" 
+          (fun major minor -> Printf.sprintf "%i.%i" major minor)
+      with _ -> raise (Failure ("Cannot parse dune-version: " ^ p.dune_version))
+    end
   | "dune-cram" ->
     if VersionCompare.compare p.dune_version "2.7.0" >= 0 then
       "(cram enable)"


### PR DESCRIPTION
The `dune-lang` specification was not handled correctly. The legacy key was not handled properly and the generated dune lang
version didn't use the semver minor number which is meaningful for dune.  This PR fixes this and I recall the whole dune lang handling here : dune lang can either be specified in :
- section `[fields]` with `dune-lang` key
- section `[tools]` with `dune` key

In both case, it will generate a `(lang dune major.minor)` corresponding to the version specified or to the minimal version compatible if both specifications are given.