### PR TITLE
Generate `version.mlt`s that support out-of-source builds

### DIFF
--- a/src/drom_lib/genVersion.ml
+++ b/src/drom_lib/genVersion.ml
@@ -23,8 +23,13 @@ let query cmd =
      else None
    with End_of_file -> None
 
-let commit_hash = query "git show -s --pretty=format:%%H"
-let commit_date = query "git show -s --pretty=format:%%ci"
+let gitdir =
+  try Sys.getenv "DUNE_SOURCEROOT" with Not_found -> ""
+
+let commit_hash =
+  query ("git -C \""^gitdir^"\" show -s --pretty=format:%%H")
+let commit_date =
+  query ("git -C \""^gitdir^"\" show -s --pretty=format:%%ci")
 let version = %S
 
 let string_option = function


### PR DESCRIPTION
Generated `version.mlt` files now supply `git` with the source path `$DUNE_SOURCEROOT`.  The behavior is unchanged if the latter environment variable is not defined.